### PR TITLE
New link to Lease docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # k8slock [![Godoc](https://godoc.org/github.com/jrhouston/k8slock?status.svg)](https://godoc.org/github.com/jrhouston/k8slock) [![Go Report Card](https://goreportcard.com/badge/github.com/jrhouston/k8slock)](https://goreportcard.com/report/github.com/jrhouston/k8slock)
 
-k8slock is a Go module that makes it easy to do distributed locking by implementing the [sync.Locker](https://golang.org/pkg/sync/#Locker) interface using the [Lease](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lease-v1-coordination-k8s-io) resource from the Kubernetes coordination API. 
+k8slock is a Go module that makes it easy to do distributed locking by implementing the [sync.Locker](https://golang.org/pkg/sync/#Locker) interface using the [Lease](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/lease-v1/) resource from the Kubernetes coordination API. 
 
 If you want to use Kubernetes to create a simple distributed lock, this module is for you.
 


### PR DESCRIPTION
The old link pointed to an outdated https server cert.