### PR TITLE
feat: allow skipping lease creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The locker can be configured using the following [functional options](https://da
 | `Clientset(kubernetes.Interface)` | Configure a custom Kubernetes Clientset. Defaults to a clientset using the local kubeconfig. |
 | `Namespace(string)` | The kubernetes namespace to store the Lease resource. Defaults to "default". |
 | `ClientID(string)` | A unique ID for the client that is trying to obtain the lock. Defaults to a random UUID. |
+| `CreateLease(bool)` | Create a Lease resource if it does not already exist. Defaults to `true`. |
 
 e.g:
 

--- a/locker_test.go
+++ b/locker_test.go
@@ -114,6 +114,9 @@ func TestSkipLeaseCreation(t *testing.T) {
 		},
 	}
 	_, err := clientset.CoordinationV1().Leases("default").Create(context.Background(), lease, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	locker, err := NewLocker(leaseName, Clientset(clientset), CreateLease(false))
 	if err != nil {

--- a/locker_test.go
+++ b/locker_test.go
@@ -76,7 +76,7 @@ func TestLockTTL(t *testing.T) {
 }
 
 func TestPanicErrorWrap(t *testing.T) {
-	locker, err := NewLocker("wrap-test")
+	locker, err := NewLocker("wrap-test", Clientset(clientset))
 	if err != nil {
 		t.Fatalf("error creating LeaseLocker: %v", err)
 	}


### PR DESCRIPTION
Hi there,

This is a great project!  I love the ease to create a cluster-wide lock without handling the low level k8s object.
However, in my use case, we would like to make helm manage the lease object, so it can be automatically cleaned up.

This PR adds a new option, `CreateLease(bool)`.  When it's `false`, the lease object will not be created.   I will appreciate if it can be accepted.  

Should you have any question, please feel free to let me know!
Sam